### PR TITLE
Fix Node 20 deprecation warnings in build workflow; bump version to 1.2.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,7 +128,7 @@ jobs:
           lipo -archs "$BIN" | grep -qw "${{ matrix.target_arch }}"
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: TrenchCoat-${{ matrix.name }}
           path: dist/TrenchCoat-${{ matrix.name }}${{ matrix.ext }}
@@ -143,7 +143,7 @@ jobs:
       contents: write
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v6
         with:
           path: artifacts
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,3 +1,3 @@
 """Trenchcoat by Warped Pinball - Tool to flash firmware and software to Warped Pinball devices."""
 
-__version__ = "1.2.1"
+__version__ = "1.2.2"


### PR DESCRIPTION
## Changes
- Bump `actions/upload-artifact` from v5 to v6, which runs on Node 24 and resolves the "Node.js 20 is deprecated" warnings seen on all four build jobs.
- Also bump `actions/download-artifact` from v5 to v6 to preempt the same warning in the release-assets job.
- Bump package version `1.2.1` → `1.2.2` in `src/__init__.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NaeVKu84UVTV8qbMPW3d3E

---
_Generated by [Claude Code](https://claude.ai/code/session_01NaeVKu84UVTV8qbMPW3d3E)_