### PR TITLE
Wait out firmware boot when identifying a freshly plugged-in board

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,3 +1,3 @@
 """Trenchcoat by Warped Pinball - Tool to flash firmware and software to Warped Pinball devices."""
 
-__version__ = "1.2.2"
+__version__ = "1.2.3"

--- a/src/interactive.py
+++ b/src/interactive.py
@@ -82,25 +82,40 @@ def select_firmware_and_system():
     return firmware, system
 
 
-def _identify_with_retry(port, attempts: int = 3, delay: float = 0.5):
-    """Identify a board, retrying on transient serial errors.
+def _identify_with_retry(port, timeout: float = 45.0, delay: float = 0.5, on_wait=None):
+    """Identify a board, retrying until ``timeout`` seconds have elapsed.
 
-    A freshly enumerated USB CDC port on Windows is often not ready for a read
-    immediately, which surfaces as ClearCommError / PermissionError(13). We open
-    a fresh connection each attempt (a half-failed handshake can leave the port
-    unusable) and back off briefly between tries. Returns the identity dict, or
-    ``None`` if every attempt fails.
+    Two things make the first attempts on a freshly plugged-in board fail:
+
+    - A just-enumerated USB CDC port on Windows is often not ready for a read
+      immediately, which surfaces as ClearCommError / PermissionError(13).
+    - The COM port enumerates seconds before the Vector firmware finishes
+      booting, and while boot code is still running the REPL does not answer
+      the raw-REPL handshake. Boot can take tens of seconds, so a fixed small
+      number of attempts always lands inside the boot window.
+
+    We therefore retry on a wall-clock deadline rather than an attempt count,
+    opening a fresh connection each attempt (a half-failed handshake can leave
+    the port unusable) and backing off briefly between tries. ``on_wait`` is
+    called once, after the first failed attempt, so callers can tell the user
+    why detection is taking a moment. Returns the identity dict, or ``None``
+    if the deadline passes without a response.
     """
-    for attempt in range(attempts):
+    deadline = time.monotonic() + timeout
+    waiting_reported = False
+    while True:
         board = Ray(port)
         try:
             return board.identify()
         except Exception:
-            if attempt + 1 < attempts:
-                time.sleep(delay)
+            if time.monotonic() >= deadline:
+                return None
+            if not waiting_reported and on_wait is not None:
+                on_wait()
+                waiting_reported = True
+            time.sleep(delay)
         finally:
             board.close()
-    return None
 
 
 def report_and_guard_boards(firmware):
@@ -129,11 +144,11 @@ def report_and_guard_boards(firmware):
     mismatch = False
     infos = []
     for port in ports:
-        info = _identify_with_retry(port)
+        info = _identify_with_retry(port, on_wait=lambda port=port: print(f"  {port}: waiting for the board to finish booting (this can take up to a minute)..."))
         if info is None:
-            # Couldn't talk to the board within the timeout/retries. Tell the
-            # user to replug (which reliably clears a wedged USB/REPL state)
-            # rather than silently hanging or skipping.
+            # Couldn't talk to the board even after waiting out a full boot.
+            # Tell the user to replug (which reliably clears a wedged USB/REPL
+            # state) rather than silently hanging or skipping.
             print(f"  {port}: no response from board.")
             print("     Try unplugging and replugging this board, then press ENTER to retry detection")
             print("     (or just press ENTER to skip detection and continue).")

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -5,10 +5,51 @@ import pytest
 
 import src.interactive as interactive
 from src.interactive import (
+    _identify_with_retry,
     _parse_release_versions,
     read_last_significant_line,
     validate_update_file,
 )
+
+
+class FakeRay:
+    """Stand-in for Ray whose identify() fails a set number of times."""
+
+    identity = {"processor": "rp2350", "board": "Pico 2 W", "system": "wpc"}
+    failures_left = 0
+
+    def __init__(self, port):
+        self.port = port
+
+    def identify(self):
+        if FakeRay.failures_left > 0:
+            FakeRay.failures_left -= 1
+            raise TimeoutError("board still booting")
+        return dict(FakeRay.identity)
+
+    def close(self):
+        pass
+
+
+class TestIdentifyWithRetry:
+    def test_keeps_retrying_while_board_boots(self, monkeypatch):
+        # A freshly plugged-in board doesn't answer until its firmware has
+        # finished booting; the retry loop must outlast many failed attempts.
+        monkeypatch.setattr(interactive, "Ray", FakeRay)
+        monkeypatch.setattr(interactive.time, "sleep", lambda s: None)
+        FakeRay.failures_left = 10
+        waits = []
+        info = _identify_with_retry("COM7", timeout=60, on_wait=lambda: waits.append(1))
+        assert info == FakeRay.identity
+        assert waits == [1]  # on_wait fires once, after the first failure
+
+    def test_gives_up_after_deadline(self, monkeypatch):
+        monkeypatch.setattr(interactive, "Ray", FakeRay)
+        monkeypatch.setattr(interactive.time, "sleep", lambda s: None)
+        FakeRay.failures_left = 10**9
+        clock = iter(range(10**9))
+        monkeypatch.setattr(interactive.time, "monotonic", lambda: next(clock))
+        assert _identify_with_retry("COM7", timeout=45) is None
 
 
 class TestParseReleaseVersions:


### PR DESCRIPTION
## Problem

Plugging a board in when prompted consistently produced:

```
Detected boards:
  COM7: no response from board.
     Try unplugging and replugging this board, then press ENTER to retry detection
  COM7: still no response - skipping detection for this board.
```

…even though the very next step (entering bootloader mode, which uses the same raw-REPL handshake) succeeded.

## Root cause

The USB CDC port enumerates within a second or two of plugging in, but the Vector firmware keeps booting for many more seconds, and the MicroPython REPL doesn't answer the Ctrl+C / raw-REPL handshake until boot code finishes. `_identify_with_retry` only made 3 attempts ~0.5s apart (~10s total including the 3s per-attempt timeouts), all of which landed inside the boot window — so detection always failed on a freshly plugged-in board, and even the manual ENTER retry often landed inside the same window. By the time bootloader entry ran, boot had completed, which is why flashing still worked.

## Fix

- `_identify_with_retry` now retries on a ~45s wall-clock deadline instead of a fixed attempt count, so a freshly plugged-in board is simply waited out while its firmware boots.
- After the first failed attempt, the user sees `waiting for the board to finish booting (this can take up to a minute)...` instead of an immediate failure.
- The existing replug-and-retry fallback is kept for genuinely wedged boards.
- Added unit tests covering the retry-until-boot-completes and give-up-after-deadline paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012br39kbz87pp8Dds8eT1o5

---
_Generated by [Claude Code](https://claude.ai/code/session_012br39kbz87pp8Dds8eT1o5)_