### PR TITLE
Fix updater hanging on the last step of the software upload

### DIFF
--- a/src/ray.py
+++ b/src/ray.py
@@ -97,7 +97,7 @@ class Ray:
     def find_board_ports(cls) -> list[str]:
         return [p.device for p in serial.tools.list_ports.comports() if cls._port_is_board(p)]
 
-    def send_command(self, script, ignore_response=False, read_timeout=None) -> str:
+    def send_command(self, script, ignore_response=False, read_timeout=None, wait_for_completion=False) -> str:
         """
         Send a script to the MicroPython board in *raw REPL mode*,
         capture and return stdout (combined into one string),
@@ -110,6 +110,15 @@ class Ray:
         ``OK`` / first output is bounded and raises ``TimeoutError`` instead of
         blocking forever when a board never drops to the REPL. Leave it ``None``
         for long-running operations whose duration is not known up front.
+
+        With ``ignore_response=True`` the response is not returned, but the
+        board still produces one (the raw REPL echoes ``OK`` and terminates
+        output with EOT bytes). ``wait_for_completion=True`` reads and discards
+        that response until the command finishes. This matters when sending
+        many commands back-to-back: if nothing ever drains the board's output,
+        the USB CDC buffers fill up, MicroPython blocks writing to stdout, and
+        the board deadlocks mid-script. Leave it False only for commands that
+        never complete normally (e.g. machine.reset / machine.bootloader).
         """
         # Make sure the serial port is open
         self.open()
@@ -133,7 +142,21 @@ class Ray:
         self.ser.write(b"\x04")
 
         if ignore_response:
-            return
+            if not wait_for_completion:
+                return
+            # Drain the raw REPL response until the command finishes. Raw REPL
+            # output ends with EOT (0x04) marking end of stdout, another EOT
+            # marking end of stderr, then the ">" prompt.
+            tail = b""
+            while True:
+                if self.ser.in_waiting > 0:
+                    chunk = self.ser.read(self.ser.in_waiting)
+                    tail = (tail + chunk)[-3:]
+                    if tail.endswith(b"\x04>"):
+                        return
+                elif deadline is not None and time.time() > deadline:
+                    raise TimeoutError(f"Board on {self.port} did not finish command within {read_timeout}s")
+                time.sleep(0.01)
 
         # read in the initial "OK" response
         buf = b""
@@ -285,7 +308,7 @@ class Ray:
             if current_len + len(line) > COMMAND_CHUNK_SIZE:
                 # send the block
                 block_script = "\n".join(current_block)
-                self.send_command(block_script, ignore_response=True)
+                self.send_command(block_script, ignore_response=True, wait_for_completion=True, read_timeout=60)
                 current_block = [line]
                 current_len = len(line)
             else:
@@ -295,11 +318,11 @@ class Ray:
         # Send any remainder
         if current_block:
             block_script = "\n".join(current_block)
-            self.send_command(block_script, ignore_response=True)
+            self.send_command(block_script, ignore_response=True, wait_for_completion=True, read_timeout=60)
 
         print()
 
-        output = self.send_command("print([check for check in hash_checks if not check[1]])", ignore_response=False)
+        output = self.send_command("print([check for check in hash_checks if not check[1]])", ignore_response=False, read_timeout=30)
 
         # find first [
         start = output.find("[")

--- a/tests/test_ray.py
+++ b/tests/test_ray.py
@@ -76,6 +76,60 @@ class TestGetFilesToUpdate:
         assert board.get_files_to_update([make_file("main.py", b"new contents")]) == ["/main.py"]
 
 
+class FakeSerial:
+    """Minimal stand-in for serial.Serial: records writes, replays queued reads."""
+
+    def __init__(self, responses=b""):
+        self.is_open = True
+        self.written = b""
+        self._pending = responses
+
+    @property
+    def in_waiting(self):
+        return len(self._pending)
+
+    def read(self, n):
+        data, self._pending = self._pending[:n], self._pending[n:]
+        return data
+
+    def write(self, data):
+        self.written += data
+
+    def flushInput(self):
+        self._pending = b""
+
+    def flushOutput(self):
+        pass
+
+
+class TestSendCommandWaitForCompletion:
+    def _board_with_serial(self, ser):
+        board = Ray.__new__(Ray)
+        board.port = "FAKE"
+        board.ser = ser
+        return board
+
+    def test_drains_response_until_prompt(self):
+        # Raw REPL response: OK, stdout, EOT, stderr, EOT, prompt.
+        ser = FakeSerial(b"OK[]\x04\x04>")
+        board = self._board_with_serial(ser)
+        result = board.send_command("print('x')", ignore_response=True, wait_for_completion=True, read_timeout=1)
+        assert result is None
+        assert ser.in_waiting == 0  # everything drained
+
+    def test_times_out_when_command_never_finishes(self):
+        ser = FakeSerial(b"OK")  # no completion trailer ever arrives
+        board = self._board_with_serial(ser)
+        with pytest.raises(TimeoutError):
+            board.send_command("while True: pass", ignore_response=True, wait_for_completion=True, read_timeout=0.2)
+
+    def test_ignore_response_without_wait_returns_immediately(self):
+        ser = FakeSerial()
+        board = self._board_with_serial(ser)
+        assert board.send_command("import machine", ignore_response=True) is None
+        assert ser.written.endswith(b"\x04")
+
+
 class FakePortInfo:
     def __init__(self, vid=None, hwid=""):
         self.vid = vid


### PR DESCRIPTION
## Problem

Users report the updater consistently freezes at the end of a software update, right after:

```
Uploading file 77 of 77: /remove_update_file.py
```

## Root cause

`Ray.write_update_to_board` sends every upload script block with `ignore_response=True`, and nothing ever reads the board's raw REPL output back. Each block still produces a response (`OK` + EOT trailers), and executed helper scripts (e.g. `remove_extra_files.py`) also `print()` output. On a full update the unread data fills the USB CDC buffers, MicroPython blocks writing to stdout, and the board deadlocks mid-script. Trench-coat then sends the final hash-verification command and waits forever for a response — with no timeout — so the tool hangs on the last progress line. The last file itself (`/remove_update_file.py`, which just deletes `/update.json` on the board) is harmless.

## Fix

- `send_command` gains a `wait_for_completion` option: with `ignore_response=True` it now reads and discards the raw REPL response until the completion trailer (`\x04\x04>`) arrives, keeping the buffers drained and pacing blocks so each finishes before the next is sent. Commands that never complete normally (`machine.reset`, `machine.bootloader`) keep the old fire-and-forget behavior.
- Upload blocks use `wait_for_completion=True` with a 60s per-block timeout, and the final hash-check read is bounded at 30s, so a stalled board now raises a clear `TimeoutError` instead of hanging silently.

## Testing

Added `FakeSerial`-based unit tests covering the drain-until-prompt path, the timeout path, and the unchanged fire-and-forget path. Full suite: 59 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PJYDEtmEfvuv2AjkPCY75c

---
_Generated by [Claude Code](https://claude.ai/code/session_01PJYDEtmEfvuv2AjkPCY75c)_