### PR TITLE
Wait for board REPL before software flash to fix silent hang

### DIFF
--- a/src/core.py
+++ b/src/core.py
@@ -343,6 +343,15 @@ def flash_software(software):
         update_files = get_files_from_update_file(software)
         for i, board in enumerate(boards):
             print(f"Flashing software to {board.port} ({i+1} of {len(ports)})")
+            # A board that was just firmware-flashed re-enumerates its serial
+            # port seconds before its application finishes booting. Wait for the
+            # REPL to actually respond before uploading, otherwise the first
+            # command (the SHA256 index) fires into a still-booting board and
+            # hangs with no output.
+            if not board.wait_until_ready(on_wait=lambda b=board: print(f"  {b.port}: waiting for the board to finish booting (this can take up to a minute)...")):
+                print(f"  {board.port}: board never became ready for software flashing.")
+                print("     Try unplugging and replugging this board, then run the program again.")
+                graceful_exit()
             # Copy files to the board
             board.write_update_to_board(update_files)
 

--- a/src/ray.py
+++ b/src/ray.py
@@ -338,6 +338,63 @@ class Ray:
 
         raise ValueError(f"Board failed to upload files: {output}")
 
+    def _drop_serial(self):
+        """Close the underlying serial handle without de-registering the
+        instance, so the next command opens a fresh connection.
+
+        A half-failed raw-REPL handshake can leave the port in a state where
+        subsequent reads never see the expected response; reopening from
+        scratch reliably clears that.
+        """
+        try:
+            if getattr(self, "ser", None):
+                self.ser.close()
+        except Exception:
+            pass
+
+    def is_repl_responsive(self, timeout: float = 3.0) -> bool:
+        """Return True if the board answers a trivial raw-REPL command within
+        ``timeout`` seconds.
+
+        Used to tell whether a board has finished booting its application and
+        dropped to a usable REPL. Any failure (port not openable, no ``OK``
+        within the timeout, unexpected output) is reported as "not ready".
+        """
+        try:
+            return self._exec_value(["print('<<<' + 'rdy' + '>>>')"], timeout) == "rdy"
+        except Exception:
+            return False
+
+    def wait_until_ready(self, timeout: float = 60.0, delay: float = 0.5, on_wait=None) -> bool:
+        """Wait until the board's REPL answers, retrying on a wall-clock deadline.
+
+        A board that was just firmware-flashed re-enumerates its USB serial
+        port seconds before the Vector application finishes booting, and while
+        boot code is still running the REPL does not answer the raw-REPL
+        handshake. Firing a command at it in that window (e.g. the SHA256 index
+        that starts a software flash) blocks forever waiting for a response
+        that never comes.
+
+        We therefore probe the REPL repeatedly until it responds or the
+        deadline passes, dropping the serial connection between attempts (a
+        half-failed handshake can leave the port unusable). ``on_wait`` is
+        called once, after the first failed attempt, so callers can tell the
+        user why flashing is taking a moment. Returns True once the board
+        responds, or False if the deadline passes first.
+        """
+        deadline = time.monotonic() + timeout
+        waiting_reported = False
+        while True:
+            if self.is_repl_responsive():
+                return True
+            if time.monotonic() >= deadline:
+                return False
+            if on_wait is not None and not waiting_reported:
+                on_wait()
+                waiting_reported = True
+            self._drop_serial()
+            time.sleep(delay)
+
     def enter_bootloader_mode(self):
         """
         Reset the board into the UF2 bootloader (might need physically to reset on some boards).
@@ -504,7 +561,10 @@ class Ray:
             "",
             "print(json.dumps(files))",
         ]
-        output = self.send_command(script_lines)
+        # Bound the read so a board that is not actually at a usable REPL
+        # (e.g. still booting its application) surfaces as a TimeoutError
+        # instead of hanging this call forever.
+        output = self.send_command(script_lines, read_timeout=120)
 
         # remove anything before first { or after last }
         start = output.find("{")

--- a/tests/test_ray.py
+++ b/tests/test_ray.py
@@ -130,6 +130,60 @@ class TestSendCommandWaitForCompletion:
         assert ser.written.endswith(b"\x04")
 
 
+class TestReplReadiness:
+    def _bare_board(self):
+        board = Ray.__new__(Ray)
+        board.port = "FAKE"
+        return board
+
+    def test_is_repl_responsive_true(self, monkeypatch):
+        board = self._bare_board()
+        monkeypatch.setattr(board, "_exec_value", lambda script, timeout: "rdy", raising=False)
+        assert board.is_repl_responsive() is True
+
+    def test_is_repl_responsive_false_on_wrong_output(self, monkeypatch):
+        board = self._bare_board()
+        monkeypatch.setattr(board, "_exec_value", lambda script, timeout: "", raising=False)
+        assert board.is_repl_responsive() is False
+
+    def test_is_repl_responsive_false_on_exception(self, monkeypatch):
+        board = self._bare_board()
+
+        def boom(script, timeout):
+            raise TimeoutError("no OK")
+
+        monkeypatch.setattr(board, "_exec_value", boom, raising=False)
+        assert board.is_repl_responsive() is False
+
+    def test_wait_until_ready_returns_true_immediately(self, monkeypatch):
+        board = self._bare_board()
+        monkeypatch.setattr(board, "is_repl_responsive", lambda: True, raising=False)
+        called = []
+        assert board.wait_until_ready(on_wait=lambda: called.append(1)) is True
+        assert called == []  # never had to tell the user we were waiting
+
+    def test_wait_until_ready_retries_then_succeeds(self, monkeypatch):
+        board = self._bare_board()
+        responses = iter([False, False, True])
+        monkeypatch.setattr(board, "is_repl_responsive", lambda: next(responses), raising=False)
+        drops = []
+        monkeypatch.setattr(board, "_drop_serial", lambda: drops.append(1), raising=False)
+        monkeypatch.setattr("src.ray.time.sleep", lambda s: None)
+        waited = []
+        assert board.wait_until_ready(on_wait=lambda: waited.append(1)) is True
+        assert waited == [1]  # on_wait fires exactly once
+        assert len(drops) == 2  # connection dropped before each retry
+
+    def test_wait_until_ready_times_out(self, monkeypatch):
+        board = self._bare_board()
+        monkeypatch.setattr(board, "is_repl_responsive", lambda: False, raising=False)
+        monkeypatch.setattr(board, "_drop_serial", lambda: None, raising=False)
+        monkeypatch.setattr("src.ray.time.sleep", lambda s: None)
+        clock = {"t": 0.0}
+        monkeypatch.setattr("src.ray.time.monotonic", lambda: clock.__setitem__("t", clock["t"] + 0.5) or clock["t"])
+        assert board.wait_until_ready(timeout=1.0) is False
+
+
 class FakePortInfo:
     def __init__(self, vid=None, hwid=""):
         self.vid = vid


### PR DESCRIPTION
## Problem

Flashing frequently hangs at the start of the **software** phase with no further output:

```
Flashing software to COM7 (1 of 1)
   <hangs here indefinitely>
```

## Root cause

After `flash_firmware()` copies the Vector UF2, the tool only waits for the board's **serial port to re-enumerate** (`wait_for_rpi_rp2` / `wait_for_n_devices`). As the code already documents in `_identify_with_retry`, the COM port enumerates *seconds before the Vector firmware finishes booting*. The freshly-flashed firmware boots straight into its application (`vector` `main.py` → `backend.go()`, "launch wifi, and server. Should not return"), running an 800 ms busy pin-scan, several seconds of `sleep`s, and then a Wi-Fi/async server loop — it is **not** at a responsive REPL.

`flash_software()` then fires its very first REPL command at that still-booting board: `write_update_to_board` → `get_files_to_update` → `sha256_index()` → `send_command(...)` **with no `read_timeout`**. When the board doesn't drop to the raw REPL and answer `OK`, that read loop spins forever with no output — exactly the observed hang.

The identify path already solved this class of problem (retry the REPL handshake on a wall-clock deadline, fresh connection per attempt); the software-flash path never got the same treatment.

## Changes

- **`Ray.wait_until_ready()`** (+ `is_repl_responsive()` / `_drop_serial()` helpers): probes the raw REPL on a wall-clock deadline, dropping the serial connection between attempts, mirroring `_identify_with_retry`.
- **`flash_software()`**: waits for each board's REPL to respond before uploading, so we wait out the boot window instead of firing into it. If a board never becomes ready, it now prints clear replug guidance instead of hanging.
- **`sha256_index()`**: bounded its read with a `read_timeout` backstop so this call can never hang indefinitely again.
- Tests for the new readiness logic (retry-then-succeed, timeout, responsiveness probe).

## Testing

- `pytest tests/` — 65 passed.
- black / isort / flake8 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011uTcgELVY833MN823djY6D

---
_Generated by [Claude Code](https://claude.ai/code/session_011uTcgELVY833MN823djY6D)_